### PR TITLE
Return promises for write & eval

### DIFF
--- a/puck.js
+++ b/puck.js
@@ -19,12 +19,6 @@ Execute expression and return the result:
     alert(d);
   });
 
-As a promise:
-
-  Puck.eval("BTN.read()").then(function(d) {
-    alert(d);
-  })
-
 Or write and wait for a result - this will return all characters,
 including echo and linefeed from the REPL so you may want to send
 `echo(0)` and use `console.log` when doing this.
@@ -32,6 +26,14 @@ including echo and linefeed from the REPL so you may want to send
   Puck.write("1+2\n", function(d) {
     alert(d);
   });
+
+Both `eval` and `write` will return a promise if no callback
+function is given as an argument.
+
+  alert( await Puck.eval("BTN.read()") )
+
+  alert( await Puck.write("1+2\n") )
+
 
 Or more advanced usage with control of the connection
  - allows multiple connections

--- a/puck.js
+++ b/puck.js
@@ -292,10 +292,16 @@ Or more advanced usage with control of the connection
   function write(data, callback, callbackNewline) {
     if (!checkIfSupported()) return;
 
+    /// If there wasn't a callback supplied then generate a promise instead
+    const result = !callback && new Promise((resolve, reject) => callback = (value, err) => {
+      if (err) reject(err);
+      else resolve(value);
+    });
+
     if (isBusy) {
       log(3, "Busy - adding Puck.write to queue");
       queue.push({type:"write", data:data, callback:callback, callbackNewline:callbackNewline});
-      return;
+      return result;
     }
 
     var cbTimeout;
@@ -342,7 +348,8 @@ Or more advanced usage with control of the connection
     if (connection && (connection.isOpen || connection.isOpening)) {
       if (!connection.txInProgress) connection.received = "";
       isBusy = true;
-      return connection.write(data, onWritten);
+      connection.write(data, onWritten);
+      return result
     }
 
     connection = connect(function(puck) {
@@ -363,6 +370,8 @@ Or more advanced usage with control of the connection
       isBusy = true;
       connection.write(data, onWritten);
     });
+
+    return result
   }
 
   // ----------------------------------------------------------

--- a/puck.js
+++ b/puck.js
@@ -408,7 +408,7 @@ Or more advanced usage with control of the connection
             return JSON.parse(d);
           } catch (e) {
             log(1, "Unable to decode " + JSON.stringify(d) + ", got " + e.toString());
-            return Promise.reject("Unable to decode " + JSON.stringify(d) + ", got " + e.toString());
+            return Promise.reject(d);
           }
         });
 

--- a/puck.js
+++ b/puck.js
@@ -380,11 +380,18 @@ Or more advanced usage with control of the connection
     write : write,
     /// Evaluate an expression and call cb with the result. Creates a connection if it doesn't exist
     eval : function(expr, cb) {
+
+      /// If there wasn't a callback supplied then generate a promise instead
+      const result = !cb && new Promise((resolve, reject) => cb = (value, err) => {
+        if (err) reject(err);
+        else resolve(value);
+      });
+
       if (!checkIfSupported()) return;
       if (isBusy) {
         log(3, "Busy - adding Puck.eval to queue");
         queue.push({type:"eval", expr:expr, cb:cb});
-        return;
+        return result;
       }
       write('\x10Bluetooth.println(JSON.stringify('+expr+'))\n', function(d) {
         try {
@@ -395,6 +402,8 @@ Or more advanced usage with control of the connection
           cb(null, "Unable to decode "+JSON.stringify(d)+", got "+e.toString());
         }
       }, true);
+
+      return result;
     },
     /// Write the current time to the Puck
     setTime : function(cb) {

--- a/puck.js
+++ b/puck.js
@@ -19,6 +19,12 @@ Execute expression and return the result:
     alert(d);
   });
 
+As a promise:
+
+  Puck.eval("BTN.read()").then(function(d) {
+    alert(d);
+  })
+
 Or write and wait for a result - this will return all characters,
 including echo and linefeed from the REPL so you may want to send
 `echo(0)` and use `console.log` when doing this.

--- a/puck.js
+++ b/puck.js
@@ -292,11 +292,16 @@ Or more advanced usage with control of the connection
   function write(data, callback, callbackNewline) {
     if (!checkIfSupported()) return;
 
-    /// If there wasn't a callback supplied then generate a promise instead
-    const result = !callback && new Promise((resolve, reject) => callback = (value, err) => {
-      if (err) reject(err);
-      else resolve(value);
-    });
+    let result;
+    /// If there wasn't a callback function, then promisify
+    if (typeof callback !== 'function') {
+      callbackNewline = callback;
+
+      result = new Promise((resolve, reject) => callback = (value, err) => {
+        if (err) reject(err);
+        else resolve(value);
+      });
+    }
 
     if (isBusy) {
       log(3, "Busy - adding Puck.write to queue");

--- a/puck.js
+++ b/puck.js
@@ -393,12 +393,6 @@ Or more advanced usage with control of the connection
         else resolve(value);
       });
 
-      if (!checkIfSupported()) return;
-      if (isBusy) {
-        log(3, "Busy - adding Puck.eval to queue");
-        queue.push({type:"eval", expr:expr, cb:cb});
-        return result;
-      }
       write('\x10Bluetooth.println(JSON.stringify('+expr+'))\n', function(d) {
         try {
           var json = JSON.parse(d);

--- a/puck.js
+++ b/puck.js
@@ -117,8 +117,7 @@ Or more advanced usage with control of the connection
     if (!queue.length) return;
     var q = queue.shift();
     log(3,"Executing "+JSON.stringify(q)+" from queue");
-    if (q.type=="eval") puck.eval(q.expr, q.cb);
-    else if (q.type=="write") puck.write(q.data, q.callback, q.callbackNewline);
+    if (q.type == "write") puck.write(q.data, q.callback, q.callbackNewline);
     else log(1,"Unknown queue item "+JSON.stringify(q));
   }
 


### PR DESCRIPTION
Hey! From our [chat on the forum](http://forum.espruino.com/conversations/360355/#comment15843446).

This adds promise support for `Puck.write` & `Puck.eval`.  I've been playing around with it a bit, and it feels quite nice!

```js
await Puck.write('reset()\n')

await Puck.write('LED1.set()\n')

console.log(`
   total= ${await Puck.eval('1 + 2 + 3')}
   button= ${await Puck.eval('BTN.read()')}
`)

const nums = Array.from({length: 10}, (_, v) => v)
const mapped = await Promise.all(nums.map(v => Puck.eval(`${v} * 10`)))
console.log(mapped)
```

The existing callback method _should_ work the same.


## Eval error change

There is one behaviour change in 0d4a9d0ec88dcdda97c6891f64bbd9c3959d15fa (can be reverted back if it's going to be a problem anywhere).

### Before

![image](https://user-images.githubusercontent.com/51385/109402359-28ddcf80-794d-11eb-80ef-0897f6c62410.png)

### After

![image](https://user-images.githubusercontent.com/51385/109402371-50349c80-794d-11eb-9f17-f6022a89695e.png)

(the "Uncaught Uncaught" is a little odd, but I guess it's kind of correct!)