### PR TITLE
Replace 'baudrate' to 'baudRate' in uart.js

### DIFF
--- a/uart.js
+++ b/uart.js
@@ -239,7 +239,7 @@
       navigator.serial.requestPort({}).then(function(port) {
         log(1, "Connecting to serial port");
         serialPort = port;
-        return port.open({ baudrate: 115200 });
+        return port.open({ baudRate: 115200 });
       }).then(function () {
         function readLoop() {
           var reader = serialPort.readable.getReader();


### PR DESCRIPTION
### Description
> UART ERROR: TypeError: Failed to execute 'open' on 'SerialPort': required member baudRate is undefined.

The member name has recently changed from 'baudrate' to 'baudRate'.

### How Has This Been Tested?
All demo projects are now working. Changing 'baudrate' to 'baudRate' fixed this error.